### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,27 +10,27 @@
     "url": "https://github.com/cyclejs/cycle-http-driver"
   },
   "dependencies": {
-    "superagent": "^1.2.0"
+    "superagent": "1.4.0"
   },
   "peerDependencies": {
     "@cycle/core": "3.x.x"
   },
   "devDependencies": {
-    "@cycle/core": "3.x.x",
-    "babel": "5.8.x",
-    "babelify": "6.1.x",
+    "@cycle/core": "3.1.0",
+    "babel": "5.8.23",
+    "babelify": "6.1.3",
     "body-parser": "1.13.3",
     "browserify": "11.0.1",
     "cookie-parser": "1.3.5",
-    "eslint": "1.0.x",
-    "eslint-config-cycle": "3.0.x",
-    "eslint-plugin-cycle": "1.0.x",
-    "eslint-plugin-no-class": "0.1.x",
-    "express": "4.13.x",
+    "eslint": "1.0.0",
+    "eslint-config-cycle": "3.0.0",
+    "eslint-plugin-cycle": "1.0.1",
+    "eslint-plugin-no-class": "0.1.0",
+    "express": "4.13.3",
     "markdox": "0.1.9",
     "mocha": "2.2.5",
     "uglify-js": "2.4.24",
-    "zuul": "^3.2.0"
+    "zuul": "3.6.0"
   },
   "scripts": {
     "eslint": "eslint src/",


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>