### PR TITLE
Update to RxJS 5.0.0-alpha.6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,5 @@
   "env": {
     "browser": true,
     "node": true
-  },
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,5 @@
   "env": {
     "browser": true,
     "node": true
-  }
+  },
 }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
     "superagent": "1.4.0"
   },
   "peerDependencies": {
-    "@cycle/core": "5.x.x"
+    "@reactivex/rxjs": "5.0.0-alpha.6"
   },
   "devDependencies": {
-    "@cycle/core": "5.0.x",
-    "rx": "4.0.6",
+    "@reactivex/rxjs": "5.0.0-alpha.6",
     "babel": "5.8.23",
     "babelify": "6.3.0",
     "body-parser": "1.14.1",

--- a/src/http-driver.js
+++ b/src/http-driver.js
@@ -108,7 +108,8 @@ function makeHTTPDriver({eager = false} = {eager: false}) {
       .map(reqOptions => {
         let response$ = createResponse$(reqOptions)
         if (eager || reqOptions.eager) {
-          response$ = response$.publishReplay(null, 1).connect()
+          response$ = response$.publishReplay(null, 1)
+          response$.connect()
           return response$
         }
         response$.request = reqOptions

--- a/src/http-driver.js
+++ b/src/http-driver.js
@@ -108,13 +108,14 @@ function makeHTTPDriver({eager = false} = {eager: false}) {
       .map(reqOptions => {
         let response$ = createResponse$(reqOptions)
         if (eager || reqOptions.eager) {
-          response$ = response$.publishReplay(null, 1)
+          response$ = response$.publishReplay(1)
           response$.connect()
           return response$
         }
         response$.request = reqOptions
         return response$
-      }).shareReplay(null, 1)
+      }).publishReplay(1)
+    response$$.connect()
     return response$$
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -23,7 +23,6 @@ function run(uri) {
         response$$.mergeAll().subscribe(
           function onNext() { assert.fail(); },
           function onError(err) {
-            debugger;
             assert.strictEqual(err.message, 'Observable of requests given to ' +
               'HTTP Driver must emit either URL strings or objects with ' +
               'parameters.'

--- a/test/common.js
+++ b/test/common.js
@@ -2,8 +2,7 @@
 /* global describe, it */
 var assert = require('assert');
 var src = require('../lib/index');
-var Cycle = require('@cycle/core');
-var Rx = require('rx');
+var Rx = require('@reactivex/rxjs');
 var makeHTTPDriver = src.makeHTTPDriver;
 
 function run(uri) {
@@ -18,12 +17,13 @@ function run(uri) {
   describe('HTTP Driver', function () {
     it('should throw when request stream emits neither string nor object',
       function(done) {
-        var request$ = Rx.Observable.just(123);
+        var request$ = Rx.Observable.of(123);
         var httpDriver = makeHTTPDriver();
         var response$$ = httpDriver(request$);
         response$$.mergeAll().subscribe(
           function onNext() { assert.fail(); },
           function onError(err) {
+            debugger;
             assert.strictEqual(err.message, 'Observable of requests given to ' +
               'HTTP Driver must emit either URL strings or objects with ' +
               'parameters.'
@@ -36,7 +36,7 @@ function run(uri) {
 
     it('should throw when given options object without url string',
       function(done) {
-        var request$ = Rx.Observable.just({method: 'post'});
+        var request$ = Rx.Observable.of({method: 'post'});
         var httpDriver = makeHTTPDriver();
         var response$$ = httpDriver(request$);
         response$$.mergeAll().subscribe(
@@ -47,14 +47,15 @@ function run(uri) {
               'options.'
             );
             done();
-          }
+          },
+          function complete() { assert.fail(); }
         );
       }
     );
 
     it('should return response metastream when given a simple URL string',
       function(done) {
-        var request$ = Rx.Observable.just(uri + '/hello');
+        var request$ = Rx.Observable.of(uri + '/hello');
         var httpDriver = makeHTTPDriver();
         var response$$ = httpDriver(request$);
         response$$.subscribe(function(response$) {
@@ -70,7 +71,7 @@ function run(uri) {
 
     it('should return response metastream when given simple options obj',
       function(done) {
-        var request$ = Rx.Observable.just({
+        var request$ = Rx.Observable.of({
           url: uri + '/pet',
           method: 'POST',
           send: {name: 'Woof', species: 'Dog'}
@@ -93,7 +94,7 @@ function run(uri) {
 
     it('should return response metastream when given another options obj',
       function(done) {
-        var request$ = Rx.Observable.just({
+        var request$ = Rx.Observable.of({
           url: uri + '/querystring',
           method: 'GET',
           query: {foo: 102030, bar: 'Pub'}
@@ -117,7 +118,7 @@ function run(uri) {
 
     it('should send 500 server errors to response$ onError',
       function(done) {
-        var request$ = Rx.Observable.just(uri + '/error');
+        var request$ = Rx.Observable.of(uri + '/error');
         var httpDriver = makeHTTPDriver();
         var response$$ = httpDriver(request$);
         response$$.subscribe(function(response$) {

--- a/test/common.js
+++ b/test/common.js
@@ -39,17 +39,17 @@ function run(uri) {
         var request$ = Rx.Observable.of({method: 'post'});
         var httpDriver = makeHTTPDriver();
         var response$$ = httpDriver(request$);
-        response$$.mergeAll().subscribe(
-          function onNext() { assert.fail(); },
-          function onError(err) {
-            assert.strictEqual(
-              err.message, 'Please provide a `url` property in the request ' +
-              'options.'
-            );
-            done();
-          },
-          function complete() { assert.fail(); }
-        );
+        response$$.mergeAll()
+          .subscribe(
+            function onNext() { assert.fail(); },
+            function onError(err) {
+              assert.strictEqual(
+                err.message, 'Please provide a `url` property in the request ' +
+                'options.'
+              );
+              done();
+            }
+          );
       }
     );
 

--- a/test/node.js
+++ b/test/node.js
@@ -7,8 +7,7 @@ require('./common')(uri);
 
 // Node.js specific ============================================================
 var assert = require('assert');
-var Cycle = require('@cycle/core');
-var Rx = require('rx');
+var Rx = require('@reactivex/rxjs');
 var src = require('../lib/index');
 var makeHTTPDriver = src.makeHTTPDriver;
 var globalSandbox = require('./support/global');
@@ -16,7 +15,7 @@ var globalSandbox = require('./support/global');
 describe('HTTP Driver in Node.js', function () {
   it('should auto-execute HTTP request when factory gets eager = true',
     function(done) {
-      var request$ = Rx.Observable.just({
+      var request$ = Rx.Observable.of({
         url: uri + '/pet',
         method: 'POST',
         send: {name: 'Woof', species: 'Dog'}
@@ -35,7 +34,7 @@ describe('HTTP Driver in Node.js', function () {
 
   it('should not auto-execute HTTP request by default',
     function(done) {
-      var request$ = Rx.Observable.just({
+      var request$ = Rx.Observable.of({
         url: uri + '/pet',
         method: 'POST',
         send: {name: 'Woof', species: 'Dog'}
@@ -52,7 +51,7 @@ describe('HTTP Driver in Node.js', function () {
 
   it('should auto-execute HTTP request if the request has eager = true',
     function(done) {
-      var request$ = Rx.Observable.just({
+      var request$ = Rx.Observable.of({
         url: uri + '/pet',
         method: 'POST',
         send: {name: 'Woof', species: 'Dog'},
@@ -72,7 +71,7 @@ describe('HTTP Driver in Node.js', function () {
 
   it('should not auto-execute HTTP request when factory gets eager = false',
     function(done) {
-      var request$ = Rx.Observable.just({
+      var request$ = Rx.Observable.of({
         url: uri + '/pet',
         method: 'POST',
         send: {name: 'Woof', species: 'Dog'}


### PR DESCRIPTION
I had to add a try/catch statement to properly catch the error being throw when there is not a url string present in a reqOptions object. It looks ugly, is there another possible solution?