### PR TITLE
Allow DELETE as request method

### DIFF
--- a/src/http-driver.js
+++ b/src/http-driver.js
@@ -19,7 +19,9 @@ function optionsToSuperagent({
   if (typeof url !== `string`) {
     throw new Error(`Please provide a \`url\` property in the request options.`)
   }
-  const sanitizedMethod = method.toLowerCase()
+  const lowerCaseMethod = method.toLowerCase()
+  const sanitizedMethod = lowerCaseMethod === `delete` ? `del` : lowerCaseMethod
+
   let request = superagent[sanitizedMethod](url)
   if (typeof request.redirects === `function`) {
     request = request.redirects(redirects)

--- a/test/common.js
+++ b/test/common.js
@@ -115,6 +115,27 @@ function run(uri) {
       }
     );
 
+    it('should return response metastream when given yet another options obj',
+      function(done) {
+        var request$ = Rx.Observable.just({
+          url: uri + '/delete',
+          method: 'DELETE',
+          query: {foo: 102030, bar: 'Pub'}
+        });
+        var httpDriver = makeHTTPDriver();
+        var response$$ = httpDriver(request$);
+        response$$.subscribe(function(response$) {
+          assert.strictEqual(response$.request.url, uri + '/delete');
+          assert.strictEqual(response$.request.method, 'DELETE');
+          response$.subscribe(function(response) {
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(response.body.deleted, true);
+            done();
+          });
+        });
+      }
+    );
+
     it('should send 500 server errors to response$ onError',
       function(done) {
         var request$ = Rx.Observable.just(uri + '/error');

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -35,4 +35,8 @@ app.get('/error', function(req, res){
   res.status(500).send('boom');
 });
 
+app.delete('/delete', function(req, res){
+  res.status(200).json({deleted: true})
+})
+
 app.listen(process.env.ZUUL_PORT);


### PR DESCRIPTION
It seems superagent's function for DELETE requests is called `del` rather than `delete`, which means that as it stands now, if the input Observable (i.e. the `HTTP` sink of `main`) emits an object like ``{url: `http://foo.bar`, method: `DELETE`}``, then the driver tries to call ``superagent[`delete`]``, which doesn't exist. I imagine that's not the desired behavior, though let me know if there's a reason that it is.

I'm new to this sort of thing, so let me know if there's something I should have done differently. It says the CI check failed for lack of credentials, but I imagine I'm not supposed to have whatever credentials those are. Is that what's supposed to happen?