### PR TITLE
Fix isolateSource to allow nested scoping ( issue #27 )

### DIFF
--- a/src/http-driver.js
+++ b/src/http-driver.js
@@ -102,10 +102,13 @@ function normalizeRequestOptions(reqOptions) {
 }
 
 function isolateSource(response$$, scope) {
-  return response$$.filter(res$ =>
+  let isolatedResponse$$ = response$$.filter(res$ =>
     Array.isArray(res$.request._namespace) &&
     res$.request._namespace.indexOf(scope) !== -1
   )
+  isolatedResponse$$.isolateSource = isolateSource
+  isolatedResponse$$.isolateSink = isolateSink
+  return isolatedResponse$$
 }
 
 function isolateSink(request$, scope) {


### PR DESCRIPTION
For nested scoping, scoped ```response$$``` should also have ```response$$.isolateSource``` and ```response$$.isolateSink```