### PR TITLE
Add a mention of linked response request behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ function main(responses) {
 
 ### Request and response cycle
 
-The request and response are linked. If you create a request without a corresponding response, by default the request will not be sent. If you want to send the request without listening for a response, you must specify `eager: true` for your request object:
+By default, request are 'lazy', i.e. they will not be sent until their response stream gets subscribed to. If you want to send the request without listening for a response, you must specify `eager: true` for your request object:
 
 ```
 return {

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ function main(responses) {
 }
 ```
 
+### Request and response cycle
+
+The request and response are linked. If you create a request without a corresponding response, by default the request will not be sent. If you want to send the request without listening for a response, you must specify `eager: true` for your request object:
+
+```
+return {
+  url: HELLO_URL,
+  method: 'POST',
+  eager: true
+};
+```
+
+Main use case is: set this option to `true` if you send POST requests and you are not interested in its response.
+
+## A thorough guide
+
 A thorough guide to the Observable API inside `main`:
 
 ```js


### PR DESCRIPTION
The "magical" linking of response and request is probably not obvious to users of the http driver. It's very easy to just glance and the docs here and expect http requests to work the way usually do.
